### PR TITLE
SED-ML aggregation functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .github/workflows/BioPortal-submission-version.json
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,32 @@
 # Changelog
+## 2.30 (OWL 2)
+- Added and unified aggregation functions for SED-ML L1V4
+  - `maximum ignoring NaN` (KISAO_0000828)
+  - `minimum ignoring NaN` (KISAO_0000829
+  - `mean ignoring NaN` (KISAO_0000825)
+  - `standard deviation ignoring NaN` (KISAO_0000826)
+  - `standard error ignoring NaN` (KISAO_0000827)
+  - `maximum` (KISAO_0000830)
+  - `minimum` (KISAO_0000840)
+  - `mean` (KISAO_0000841)
+  - `standard deviation` (KISAO_0000842)
+  - `standard error`  (KISAO_0000843)
+  - `sum ignoring NaN` (KISAO_0000844)
+  - `sum` (KISAO_0000845) 
+  - `product ignoring NaN` (KISAO_0000846)
+  - `product` (KISAO_0000847)
+  - `cumulative sum` (KISAO_0000848)
+  - `cumulative sum  ignoring NaN` (KISAO_0000849)
+  - `cumulative product ignoring NaN` (KISAO_0000850)
+  - `cumulative product` (KISAO_0000851)
+  - `count ignoring NaN` (KISAO_0000852): number of non-zero elements, ignoring NaN entries
+  - `count` (KISAO_0000853): number of non-zero elements, ignoring NaN entries
+  - `length ignoring NaN` (KISAO_0000854): number of elements, ignoring NaN entries
+  - `length` (KISAO_0000855): number of elements, ignoring NaN entries
+  - `median ignoring NaN` (KISAO_0000856)
+  - `median` (KISAO_0000857)
+  - `variance ignoring NaN` (KISAO_0000858)
+  - `variance` (KISAO_0000859)
 
 ## 2.29 (OWL 2)
 - Added term for number of simulation steps per simulation output needed by BioNetGen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,7 @@ Contributions to KiSAO should adhere to the following conventions:
 - URIs of terms should follow the pattern `http://www.biomodels.net/kisao/KISAO#KISAO_\d{7,7}`
 - URIs should be assigned sequentially, starting from the greatest id
 - Labels should start with a lowercase letter, except for proper names such as the name of a person (e.g., `Gillespie's Algorithm`)
+- Labels should not contain special characters or brackets
 
 ## Submitting changes
 

--- a/kisao.owl
+++ b/kisao.owl
@@ -16,7 +16,7 @@
         <dc:rights>Artistic License 2.0</dc:rights>
         <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://identifiers.org/pubmed/22027554</rdfs:seeAlso>
         <rdfs:label xml:lang="en">Kinetic Simulation Algorithm Ontology (KiSAO)</rdfs:label>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2.29</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2.30</owl:versionInfo>
         <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://co.mbine.org/standards/kisao</rdfs:seeAlso>
         <protege:defaultLanguage>en</protege:defaultLanguage>
         <skos:definition xml:lang="en">The Kinetic Simulation Algorithm Ontology (KiSAO) classifies algorithms available for the simulation and analysis of models in biology, and their characteristics and the parameters required for their use.</skos:definition>

--- a/kisao.owl
+++ b/kisao.owl
@@ -1,26 +1,26 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns="http://www.biomodels.net/kisao/KISAO#"
      xml:base="http://www.biomodels.net/kisao/KISAO"
-     xmlns:dc="http://purl.org/dc/terms/"
-     xmlns:obo="http://purl.obolibrary.org/obo/"
      xmlns:ont="http://www.co-ode.org/ontologies/ont.owl#"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
      xmlns:kisao="http://www.biomodels.net/kisao/KISAO#"
-     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#">
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:protege="http://protege.stanford.edu/plugins/owl/protege#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:dc="http://purl.org/dc/terms/">
     <owl:Ontology rdf:about="http://www.biomodels.net/kisao/KISAO#">
-        <protege:defaultLanguage>en</protege:defaultLanguage>
         <dc:rights>Artistic License 2.0</dc:rights>
-        <rdfs:comment xml:lang="en">This is a core version which contains all but deprecated classes.</rdfs:comment>
-        <rdfs:label xml:lang="en">Kinetic Simulation Algorithm Ontology (KiSAO)</rdfs:label>
-        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://co.mbine.org/standards/kisao</rdfs:seeAlso>
         <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://identifiers.org/pubmed/22027554</rdfs:seeAlso>
+        <rdfs:label xml:lang="en">Kinetic Simulation Algorithm Ontology (KiSAO)</rdfs:label>
         <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2.29</owl:versionInfo>
+        <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://co.mbine.org/standards/kisao</rdfs:seeAlso>
+        <protege:defaultLanguage>en</protege:defaultLanguage>
         <skos:definition xml:lang="en">The Kinetic Simulation Algorithm Ontology (KiSAO) classifies algorithms available for the simulation and analysis of models in biology, and their characteristics and the parameters required for their use.</skos:definition>
+        <rdfs:comment xml:lang="en">This is a core version which contains all but deprecated classes.</rdfs:comment>
     </owl:Ontology>
     
 
@@ -14894,9 +14894,9 @@ This method only involves evaluations of f. This method is suitable for non-stif
 
     <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000825">
         <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
-        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">06-03-2021</dc:created>
-        <dc:creator xml:lang="en">LPS</dc:creator>
-        <rdfs:label xml:lang="en">mean</rdfs:label>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-03</dc:created>
+        <dc:creator xml:lang="en">LPS, MK</dc:creator>
+        <rdfs:label xml:lang="en">mean ignoring NaN</rdfs:label>
         <skos:definition xml:lang="en">The mean (average) of a set of values, ignoring NaN entries.</skos:definition>
     </owl:Class>
     
@@ -14906,9 +14906,9 @@ This method only involves evaluations of f. This method is suitable for non-stif
 
     <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000826">
         <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
-        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">06-03-2021</dc:created>
-        <dc:creator xml:lang="en">LPS</dc:creator>
-        <rdfs:label xml:lang="en">standard deviation</rdfs:label>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-03</dc:created>
+        <dc:creator xml:lang="en">LPS, MK</dc:creator>
+        <rdfs:label xml:lang="en">standard deviation ignoring NaN</rdfs:label>
         <skos:definition xml:lang="en">The standard deviation of a set of values, ignoring NaN entries.</skos:definition>
     </owl:Class>
     
@@ -14918,9 +14918,9 @@ This method only involves evaluations of f. This method is suitable for non-stif
 
     <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000827">
         <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
-        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">06-03-2021</dc:created>
-        <dc:creator xml:lang="en">LPS</dc:creator>
-        <rdfs:label xml:lang="en">standard error</rdfs:label>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-03</dc:created>
+        <dc:creator xml:lang="en">LPS, MK</dc:creator>
+        <rdfs:label xml:lang="en">standard error ignoring NaN</rdfs:label>
         <skos:definition xml:lang="en">The standard error of a set of values, ignoring NaN entries.</skos:definition>
     </owl:Class>
     
@@ -14930,9 +14930,9 @@ This method only involves evaluations of f. This method is suitable for non-stif
 
     <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000828">
         <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
-        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">06-03-2021</dc:created>
-        <dc:creator xml:lang="en">LPS</dc:creator>
-        <rdfs:label xml:lang="en">maximum</rdfs:label>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-03</dc:created>
+        <dc:creator xml:lang="en">LPS, MK</dc:creator>
+        <rdfs:label xml:lang="en">maximum ignoring NaN</rdfs:label>
         <skos:definition xml:lang="en">The maximum value of a set of values, ignoring NaN entries.</skos:definition>
     </owl:Class>
     
@@ -14942,12 +14942,224 @@ This method only involves evaluations of f. This method is suitable for non-stif
 
     <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000829">
         <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
-        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">06-03-2021</dc:created>
-        <dc:creator xml:lang="en">LPS</dc:creator>
-        <rdfs:label xml:lang="en">minimum</rdfs:label>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-06-03</dc:created>
+        <dc:creator xml:lang="en">LPS, MK</dc:creator>
+        <rdfs:label xml:lang="en">minimum ignoring NaN</rdfs:label>
         <skos:definition xml:lang="en">The minimum value of a set of values, ignoring NaN entries.</skos:definition>
     </owl:Class>
     
+
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000830 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000830">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">maximum</rdfs:label>
+        <skos:definition xml:lang="en">The maximum of a set of values. If the values contain NaN the maximum is NaN.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000840 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000840">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">minimum</rdfs:label>
+        <skos:definition xml:lang="en">The minimum of a set of values. If the values contain NaN the minimum is NaN.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000841 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000841">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">mean</rdfs:label>
+        <skos:definition xml:lang="en">The mean of a set of values. If the values contain NaN the mean is NaN.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000842 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000842">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">standard deviation</rdfs:label>
+        <skos:definition xml:lang="en">The standard deviation of a set of values. If the values contain NaN the standard deviation is NaN.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000843 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000843">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">standard error</rdfs:label>
+        <skos:definition xml:lang="en">The standard error of a set of values. If the values contain NaN the standard deviation is NaN.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000844 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000844">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">sum ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The sum of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000845 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000845">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">sum</rdfs:label>
+        <skos:definition xml:lang="en">The sum of a set of values. If the values contain NaN the sum is NaN.</skos:definition>
+    </owl:Class>
+
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000846 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000846">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">product ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The product of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000847 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000847">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">product</rdfs:label>
+        <skos:definition xml:lang="en">The product of a set of values. If the values contain NaN the product is NaN.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000848 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000848">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">cumulative sum ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The cumulative sum of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000849 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000849">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">cumulative sum</rdfs:label>
+        <skos:definition xml:lang="en">The cumulative sum of a set of values. If the values contain NaN the cumulative sum is NaN.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000850 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000850">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">cumulative product ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The cumulative product of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000851 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000851">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">cumulative product</rdfs:label>
+        <skos:definition xml:lang="en">The cumulative product of a set of values. If the values contain NaN the cumulative product is NaN.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000852 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000852">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">count ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The number of non-zero elements of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000853 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000853">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">count</rdfs:label>
+        <skos:definition xml:lang="en">The number of non-zero elements of a set of values. If the values contain NaN the count is NaN.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000854 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000854">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">length ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The number of elements of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000855 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000855">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">length</rdfs:label>
+        <skos:definition xml:lang="en">The number of elements of a set of values.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000856 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000856">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">median ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The median of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000857 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000857">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">median</rdfs:label>
+        <skos:definition xml:lang="en">The median of a set of values. If the values contain NaN the median is NaN.</skos:definition>
+    </owl:Class>
+    
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000858 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000858">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">variance ignoring NaN</rdfs:label>
+        <skos:definition xml:lang="en">The variance of a set of values, ignoring Nan entries.</skos:definition>
+    </owl:Class>
+
+    <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000859 -->
+
+    <owl:Class rdf:about="http://www.biomodels.net/kisao/KISAO#KISAO_0000859">
+        <rdfs:subClassOf rdf:resource="http://www.biomodels.net/kisao/KISAO#KISAO_0000824"/>
+        <dc:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-10-09</dc:created>
+        <dc:creator xml:lang="en">MK</dc:creator>
+        <rdfs:label xml:lang="en">variance</rdfs:label>
+        <skos:definition xml:lang="en">The variance of a set of values. If the values contain NaN the variance is NaN.</skos:definition>
+    </owl:Class>
 
 
     <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000831 -->
@@ -14960,7 +15172,6 @@ This method only involves evaluations of f. This method is suitable for non-stif
         <skos:definition xml:lang="en">A variable of a model or simulation.</skos:definition>
     </owl:Class>
     
-
 
     <!-- http://www.biomodels.net/kisao/KISAO#KISAO_0000832 -->
 
@@ -15086,11 +15297,7 @@ This method only involves evaluations of f. This method is suitable for non-stif
         <rdfs:label xml:lang="en">temperature</rdfs:label>
         <skos:definition>The intensive quantity temperature.</skos:definition>
     </owl:Class>
-    <rdf:Description>
-        <rdfs:comment xml:lang="en">EXACT</rdfs:comment>
-    </rdf:Description>
     
-
 
     <!-- 
     ///////////////////////////////////////////////////////////////////////////////////////
@@ -15884,5 +16091,5 @@ This method only involves evaluations of f. This method is suitable for non-stif
 
 
 
-<!-- Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi -->
+<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
 

--- a/kisao_full.owl
+++ b/kisao_full.owl
@@ -19,7 +19,7 @@
         <rdfs:comment xml:lang="en">Kinetic Simulation Algorithm Ontology (full version, containing deprecated classes)</rdfs:comment>
         <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://co.mbine.org/standards/kisao</rdfs:seeAlso>
         <rdfs:seeAlso rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">http://identifiers.org/pubmed/22027554</rdfs:seeAlso>
-        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2.29</owl:versionInfo>
+        <owl:versionInfo rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">2.30</owl:versionInfo>
         <skos:definition xml:lang="en">The Kinetic Simulation Algorithm Ontology (KiSAO) classifies algorithms available for the simulation and analysis of models in biology, and their characteristics and the parameters required for their use.</skos:definition>
     </owl:Ontology>
     


### PR DESCRIPTION
Added and unified aggregation functions for SED-ML L1V4 via KISAO-v2.30
  - `maximum ignoring NaN` (KISAO_0000828)
  - `minimum ignoring NaN` (KISAO_0000829
  - `mean ignoring NaN` (KISAO_0000825)
  - `standard deviation ignoring NaN` (KISAO_0000826)
  - `standard error ignoring NaN` (KISAO_0000827)
  - `maximum` (KISAO_0000830)
  - `minimum` (KISAO_0000840)
  - `mean` (KISAO_0000841)
  - `standard deviation` (KISAO_0000842)
  - `standard error`  (KISAO_0000843)
  - `sum ignoring NaN` (KISAO_0000844)
  - `sum` (KISAO_0000845) 
  - `product ignoring NaN` (KISAO_0000846)
  - `product` (KISAO_0000847)
  - `cumulative sum` (KISAO_0000848)
  - `cumulative sum  ignoring NaN` (KISAO_0000849)
  - `cumulative product ignoring NaN` (KISAO_0000850)
  - `cumulative product` (KISAO_0000851)
  - `count ignoring NaN` (KISAO_0000852): number of non-zero elements, ignoring NaN entries
  - `count` (KISAO_0000853): number of non-zero elements, ignoring NaN entries
  - `length ignoring NaN` (KISAO_0000854): number of elements, ignoring NaN entries
  - `length` (KISAO_0000855): number of elements, ignoring NaN entries
  - `median ignoring NaN` (KISAO_0000856)
  - `median` (KISAO_0000857)
  - `variance ignoring NaN` (KISAO_0000858)
  - `variance` (KISAO_0000859)